### PR TITLE
Adding environment variable support

### DIFF
--- a/lib/soda/sauce.js
+++ b/lib/soda/sauce.js
@@ -28,8 +28,25 @@ var Client = require('./client');
  */
 
 var SauceClient = exports = module.exports = function SauceClient(options) {
-  this.host = 'saucelabs.com';
-  this.port = 4444;
+  /*
+  * Check sauce environment variables, for development
+  * and alternative ondemand hosts
+  */
+  this.host = process.env['SAUCE_HOST'] || 'saucelabs.com';
+  this.port = process.env['SAUCE_PORT'] || 4444;
+  
+  // Check sauce env variables, and provide defaults
+  options.os = options.os || process.env['SAUCE_OS'] || 'Linux';
+  options.url = options.url || process.env['SAUCE_BROWSER_URL'];
+  options.browser = options.browser || process.env['SAUCE_BROWSER'] || 'firefox';
+  options.username = options.username || process.env['SAUCE_USERNAME'];
+  options['access-key'] = options['access-key'] || process.env['SAUCE_ACCESS_KEY'];
+  
+  // Allow users to specify an empty browser-version
+  options['browser-version'] = (options['browser-version'] == undefined) ? 
+                                (process.env['SAUCE_BROWSER_VERSION'] || "") : 
+                                (options['browser-version'] || "");
+  
   this.url = options.url;
   this.username = options.username;
   this.accessKey = options['access-key'];


### PR DESCRIPTION
Many users have been asking for environment variables to configure their test environments when running from CI. I implemented this last week in the python client.. figured with the release of this today it would be nice to provide that functionality from the beginning.

Really enjoying using this project already.

Adam
