### PR TITLE
Use ondemand.saucelabs.com:80 instead of saucelabs.com:4444 by default

### DIFF
--- a/lib/soda/sauce.js
+++ b/lib/soda/sauce.js
@@ -1,4 +1,3 @@
-
 /*!
  * Soda - Sauce
  * Copyright(c) 2010 LearnBoost <tj@learnboost.com>
@@ -40,8 +39,8 @@ var Client = require('./client');
 
 var SauceClient = exports = module.exports = function SauceClient(options) {
   options = options || {};
-  this.host = process.env.SAUCE_HOST || 'saucelabs.com';
-  this.port = process.env.SAUCE_PORT || 4444;
+  this.host = process.env.SAUCE_HOST || 'ondemand.saucelabs.com';
+  this.port = process.env.SAUCE_PORT || 80;
   
   // Check sauce env variables, and provide defaults
   options.os = options.os || process.env.SAUCE_OS || 'Linux';


### PR DESCRIPTION
We provide Selenium endpoints at both saucelabs.com:4444 and ondemand.saucelabs.com:80. Some enterprise firewalls block outgoing port 4444 (I know, right?), which is why we created ondemand.saucelabs.com:80. Some users get confused by things not working when their firewall is blocking things. There's no cost to using ondemand.saucelabs.com, so we think it's best if you make that the default.
