### PR TITLE
Added support for the Selenium `store` Accessor 

### DIFF
--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -435,6 +435,7 @@ exports.accessors.map(function(cmd){
       'get' + cmd
     , 'assert' + cmd
     , 'assertNot' + cmd
+    , 'store' + cmd
     , 'verify' + cmd
     , 'verifyNot' + cmd
     , 'waitFor' + cmd


### PR DESCRIPTION
storing variable is useful 
http://release.seleniumhq.org/selenium-core/0.8.0/reference.html#storedVars

Not sure why it wasn't part of your accessors. Very trivial change. I've tested it and it works.

Btw, I would be interested in more test examples. How do you architect the code when it starts getting loooooooooong and messy? Thanks!
