### PR TITLE
Support using POST request if command length is larger than 2K

### DIFF
--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -89,11 +89,27 @@ Client.prototype.command = function(cmd, args, fn){
   // Path construction
   var path = this.commandPath(cmd, args);
 
-  // Request
-  var req = client.request('GET'
+  var req;
+  
+  // Selenium RC can support POST request: http://svn.openqa.org/fisheye/changelog/selenium-rc/?cs=1898,    
+  // we need to switch to use POST if the URL's is too long (Below I use the Internet Explorer's limit).
+  // See also: http://jira.openqa.org/browse/SRC-50
+  if (path.length > 2048 && (this.host + path ).length > 2083) {
+    postData = this.commandPath(cmd, args).replace('/selenium-server/driver/?', "");
+    req = client.request('POST'
     , path
-    , { Host: this.host + (this.port ? ':' + this.port : '') });
+    , { Host: this.host + (this.port ? ':' + this.port : '') 
+        , 'Content-Length': postData.length
+        , 'Content-Type': 'application/x-www-form-urlencoded'
+    });
     
+    req.write(postData);
+  } else {    
+    req = client.request('GET'
+    , path
+    , { Host: this.host + (this.port ? ':' + this.port : '') });    
+  }
+  
   req.on('response', function(res){
     res.body = '';
     res.setEncoding('utf8');


### PR DESCRIPTION
Selenium RC can support POST request: http://svn.openqa.org/fisheye/changelog/selenium-rc/?cs=1898, this update allow the client to switch to use POST if the URL's is too long.

See also: http://jira.openqa.org/browse/SRC-50
