### PR TITLE
Time outs are ignored and masked as success.

### DIFF
--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -115,7 +115,8 @@ Client.prototype.command = function(cmd, args, fn){
     res.setEncoding('utf8');
     res.on('data', function(chunk){ res.body += chunk; });
     res.on('end', function(){
-      if (res.body.indexOf('ERROR') === 0) {
+      if (res.body.indexOf('ERROR') === 0 ||
+          res.body.indexOf('Timed out after ') === 0) {
         var err = res.body.replace(/^ERROR: */, '');
         err = cmd + '(' + args.join(', ') + '): ' + err; 
         fn(new Error(err), res.body, res);


### PR DESCRIPTION
`client.js` checks only for "ERROR" responses.
The proposed fix also looks for "Timed out after" responses.
