### PR TITLE
thanks for your thoughts.

### DIFF
--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -83,6 +83,11 @@ Client.prototype.session = function(fn){
 Client.prototype.command = function(cmd, args, fn){
   this.emit('command', cmd, args);
 
+  if (cmd === 'eval') {
+    fn(null, null, null);
+    return this;
+  }
+
   // HTTP client
   var client = http.createClient(this.port, this.host);
 
@@ -246,6 +251,21 @@ Client.prototype.enqueue = function(cmd, args, fn){
 Client.prototype.and = function(fn){
   fn.call(this, this);
   return this;
+};
+
+/**
+ * Arbitrary callback when using the chaining api.
+ * Unlike and() this injects itself in the queue to only execute
+ * AFTER any existing selenium calls are completed.
+ */
+Client.prototype.then = function(fn){
+  // Queue the command invocation
+  if (this.queue) {
+    return this.enqueue('eval', [fn]);
+  // Direct call
+  } else {
+    return this.command('eval', [], fn);
+  }
 };
 
 /**


### PR DESCRIPTION
add then() to accompany and().  then() takes it's callback and enqueues it to guarantee that it will execute in order immediately after whatever the last selenium call was queued and immediately before the next one.

there are some cases where the combination of and() (which fires immediately) and inline callbacks (which fire after success on any individual selenium call) aren't adequate.

when trying to gain an access token for a facebook user, you get redirected to a url with the access token in the url's path.  i want to be able to arbitrarily execute code once that access token has been gathered, but i want to still queue up my other selenium queries without having to wait for that callback to fire..

in my basic tests where i call a browser.waitFor*, then a browser.then(function(..)), followed by another browser.open(...) or whatever, the then seems to fire at the right moment, only after the waitFor is completed, and before the open() begins...
