### PR TITLE
Small fix to prevent _end() from crashing

### DIFF
--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -190,7 +190,7 @@ Client.prototype.__defineGetter__('chain', function(){
  */
 
 Client.prototype.end = function(fn){
-  this._done = function(){this.queue = null; return fn.apply(this, arguments)};
+  this._done = function(){this.queue = []; return fn.apply(this, arguments)};
   this.queue.shift()();
 };
 


### PR DESCRIPTION
```
Caught Exception
TypeError: Cannot call method 'shift' of null
    at Client.end (/Users/pac/server/market/node_modules/soda/lib/soda/client.js:194:14)
    at [object Object].<anonymous> (/Users/pac/server/market/features/step_definitions/asks.js:83:6)
```
