### PR TITLE
Catching HTTP client errors and sending them to callback

### DIFF
--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -129,6 +129,10 @@ Client.prototype.command = function(cmd, args, fn){
     return this;
   });
 
+  req.on('error', function(err) {
+    fn(err);
+  });
+
   if(postData) {
     req.write(postData);
   }

--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -86,6 +86,11 @@ Client.prototype.command = function(cmd, args, fn){
   // HTTP client
   var client = http.createClient(this.port, this.host);
 
+  // Send HTTP client errors to callback
+  client.on('error', function(err) {
+    fn(err);
+  });
+
   // Path construction
   var path = this.commandPath(cmd, args);
 
@@ -108,6 +113,9 @@ Client.prototype.command = function(cmd, args, fn){
     req = client.request('GET'
     , path
     , { Host: this.host + (this.port ? ':' + this.port : '') });    
+    req.on('error', function(exception) {
+
+    });
   }
   
   req.on('response', function(res){

--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -113,9 +113,6 @@ Client.prototype.command = function(cmd, args, fn){
     req = client.request('GET'
     , path
     , { Host: this.host + (this.port ? ':' + this.port : '') });    
-    req.on('error', function(exception) {
-
-    });
   }
   
   req.on('response', function(res){


### PR DESCRIPTION
On sending commands HTTP client errors were causing the application to exit instead of bubbling up to the callback (as expected).
