### PR TITLE
Switch to new HTTP API and force use of keepalives in a socket per client

### DIFF
--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -83,8 +83,13 @@ Client.prototype.session = function(fn){
 Client.prototype.command = function(cmd, args, fn){
   this.emit('command', cmd, args);
 
-  // HTTP client
-  var client = http.createClient(this.port, this.host);
+  if (!this.agent) {
+    // Create a dedicated HTTP agent pool for this client, limited to one socket.
+    // This means all Selenium commands are sent on one socket with keepalives, rather than
+    // a new socket created for each request, as we never reach the maxSockets default of 5 otherwise.
+    this.agent = new http.Agent();
+    this.agent.maxSockets = 1;
+  }
 
   // Path construction
   var path = this.commandPath(cmd, args);
@@ -96,18 +101,26 @@ Client.prototype.command = function(cmd, args, fn){
   // See also: http://jira.openqa.org/browse/SRC-50
   if (path.length > 2048 && (this.host + path ).length > 2083) {
     postData = this.commandPath(cmd, args).replace('/selenium-server/driver/?', "");
-    req = client.request('POST'
-    , path
-    , { Host: this.host + (this.port ? ':' + this.port : '') 
-        , 'Content-Length': postData.length
+    req = http.request({
+      host: this.host,
+      port: this.port,
+      method: 'POST',
+      path: path,
+      agent: false, // use new socket for each POST
+      headers: {
+          'Content-Length': postData.length
         , 'Content-Type': 'application/x-www-form-urlencoded'
+      }
     });
-    
     req.write(postData);
-  } else {    
-    req = client.request('GET'
-    , path
-    , { Host: this.host + (this.port ? ':' + this.port : '') });    
+  } else {
+    req = http.request({
+      host: this.host,
+      port: this.port,
+      method: 'GET',
+      path: path,
+      agent: this.agent,
+    });
   }
   
   req.on('response', function(res){

--- a/lib/soda/sauce.js
+++ b/lib/soda/sauce.js
@@ -48,7 +48,7 @@ var SauceClient = exports = module.exports = function SauceClient(options) {
   options.browser = options.browser || process.env.SAUCE_BROWSER || 'firefox';
   options.username = options.username || process.env.SAUCE_USERNAME;
   options['access-key'] = options['access-key'] || process.env.SAUCE_ACCESS_KEY;
-  options.['max-duration'] = options['max-duration'] || 300;
+  options['max-duration'] = options['max-duration'] || 300;
 
   // Allow users to specify an empty browser-version
   options['browser-version'] = options['browser-version'] == undefined

--- a/lib/soda/sauce.js
+++ b/lib/soda/sauce.js
@@ -48,7 +48,8 @@ var SauceClient = exports = module.exports = function SauceClient(options) {
   options.browser = options.browser || process.env.SAUCE_BROWSER || 'firefox';
   options.username = options.username || process.env.SAUCE_USERNAME;
   options['access-key'] = options['access-key'] || process.env.SAUCE_ACCESS_KEY;
-  
+  options.['max-duration'] = options['max-duration'] || 300;
+
   // Allow users to specify an empty browser-version
   options['browser-version'] = options['browser-version'] == undefined
     ? (process.env.SAUCE_BROWSER_VERSION || '')


### PR DESCRIPTION
I made a switch from http.createClient to http.request, the new API. I also made a custom agent for each client that restricts a client to one socket, otherwise the default maxSockets of 5 means each new command to Selenium opens a new connection to the server. When dealing with Saucelabs, the Selenium server is quite a long way away, so the socket open time becomes quite significant.
