### PR TITLE
createClient is deprecated

### DIFF
--- a/lib/soda/client.js
+++ b/lib/soda/client.js
@@ -84,7 +84,7 @@ Client.prototype.command = function(cmd, args, fn){
   this.emit('command', cmd, args);
 
   // HTTP client
-  var client = http.createClient(this.port, this.host);
+  var client = http.request(this.port, this.host);
 
   // Path construction
   var path = this.commandPath(cmd, args);


### PR DESCRIPTION
http.createClient is deprecated. Use `http.request` instead.
